### PR TITLE
Add Android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,20 @@
+cc_binary {
+    name: "initshim",
+    recovery: true,
+    cflags: [
+        "-Werror",
+        "-Wno-macro-redefined",
+        "-std=gnu11"
+    ],
+    local_include_dirs: [
+        "include"
+    ],
+    srcs: [
+        "src/main.c",
+        "src/drm.c"
+    ],
+    whole_static_libs: [
+        "libdrm-static",
+    ],
+    static_executable: true,
+}

--- a/include/drm.h
+++ b/include/drm.h
@@ -1,8 +1,13 @@
 #ifndef INITSHIM_DRM_H
 #define INITSHIM_DRM_H
 
+#if __has_include(<drm/drm.h>) && __has_include(<drm/drm_mode.h>)
+#include <drm/drm.h>
+#include <drm/drm_mode.h>
+#else
 #include <libdrm/drm.h>
 #include <libdrm/drm_mode.h>
+#endif
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 

--- a/src/drm.c
+++ b/src/drm.c
@@ -176,6 +176,8 @@ int createDumbFB(int *fd, drmModeResPtr *res, struct framebuffer *fb)
     fb->fd = *fd;
     fb->connector = connectorPtr;
     fb->resolution = resolution;
+
+    return 0;
 }
 
 int initDrm()


### PR DESCRIPTION
Required AOSP patches:
- `external/libdrm/`:
```patch
diff --git a/Android.bp b/Android.bp
index dbac5626..8f0af31b 100644
--- a/Android.bp
+++ b/Android.bp
@@ -108,3 +108,21 @@ cc_library {
         "com.android.virt",
     ],
 }
+
+cc_library_static {
+    name: "libdrm-static",
+    recovery_available: true,
+    defaults: [
+        "libdrm_defaults",
+        "libdrm_sources",
+    ],
+
+    export_include_dirs: ["include/drm", "android"],
+
+    cflags: [
+        "-Wno-enum-conversion",
+        "-Wno-pointer-arith",
+        "-Wno-sign-compare",
+        "-Wno-tautological-compare",
+    ],
+}
```
- `build/make/`:
```patch
diff --git a/core/Makefile b/core/Makefile
index 5c353bd544..e9ef786488 100644
--- a/core/Makefile
+++ b/core/Makefile
@@ -2470,6 +2470,6 @@ $(INTERNAL_RECOVERY_RAMDISK_FILES_TIMESTAMP): $(MKBOOTFS) $(COMPRESSION_COMMAND_
        # Use rsync because "cp -Rf" fails to overwrite broken symlinks on Mac.
        rsync -a --exclude=sdcard $(IGNORE_RECOVERY_SEPOLICY) $(IGNORE_CACHE_LINK) $(TARGET_ROOT_OUT) $(TARGET_RECOVERY_OUT)
        # Modifying ramdisk contents...
-        ln -sf /system/bin/init $(TARGET_RECOVERY_ROOT_OUT)/init
+        ln -sf /system/bin/initshim $(TARGET_RECOVERY_ROOT_OUT)/init
        # Removes $(TARGET_RECOVERY_ROOT_OUT)/init*.rc EXCEPT init.recovery*.rc.
        find $(TARGET_RECOVERY_ROOT_OUT) -maxdepth 1 -name 'init*.rc' -type f -not -name "init.recovery.*.rc" | xargs rm -f
```
- `system/core/`:
```patch
diff --git a/init/Android.bp b/init/Android.bp
index dce50ea4b..3cb2ceb02 100644
--- a/init/Android.bp
+++ b/init/Android.bp
@@ -309,6 +309,7 @@ cc_binary {
                 "make_f2fs.recovery",
                 "mke2fs.recovery",
                 "sload_f2fs.recovery",
+                "initshim",
             ],
         },
     },
```